### PR TITLE
Fix: OUTSMARTLY_API_ORIGIN env var name

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,7 +1,8 @@
 import fetch, { Response, Headers, RequestInit } from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
 
-const origin = process.env.OUTSMARLY_API_ORIGIN ?? 'https://api.edgebailey.com';
+const origin =
+  process.env.OUTSMARTLY_API_ORIGIN ?? 'https://api.edgebailey.com';
 
 export class APIError extends Error {
   constructor(public response: Response, public json: any) {


### PR DESCRIPTION
Thought I'd make a quick PR to fix this since I remembered finding it, though not sure of the implications of releasing it. Doesn't look like I'm able to run tests locally but am not seeing this env var referenced anywhere else in the repo.