### PR TITLE
Feature: pass analysisDir option through to Babel plugin

### DIFF
--- a/packages/next-plugin-outsmartly/src/babel-preset-build.js
+++ b/packages/next-plugin-outsmartly/src/babel-preset-build.js
@@ -1,3 +1,6 @@
-module.exports = function babelPresetBuild(options, config) {
-  options.plugins.push('@outsmartly/babel-plugin-outsmartly-react');
+const BABEL_PLUGIN_NAME = '@outsmartly/babel-plugin-outsmartly-react';
+
+module.exports = function babelPresetBuild(options, { analysisDir = null } = {}) {
+  const babelPluginConfig = analysisDir ? [BABEL_PLUGIN_NAME, { analysisDir }] : BABEL_PLUGIN_NAME;
+  options.plugins.push(babelPluginConfig);
 };


### PR DESCRIPTION
https://github.com/outsmartly/zerorestriction/blob/main/.babelrc.json#L5-L10 is causing a Babel to throw an error about the Babel plugin being set twice in next@10.1.3. This is because the latest version of our Next plugin already sets this. To be able to configure `analysisDir`, I've added the ability to pass through this config value when initializing the Next plugin. 