### PR TITLE
@outsmartly/cli@0.0.81

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29349,7 +29349,7 @@
     },
     "packages/cli": {
       "name": "@outsmartly/cli",
-      "version": "0.0.77",
+      "version": "0.0.81",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -29377,7 +29377,7 @@
         "fs-extra": "^8.1.0",
         "inquirer": "^7.3.3",
         "multiline-template": "^1.1.0",
-        "node-fetch": "3.0.0-beta.9",
+        "node-fetch": "^3.0.0-beta.9",
         "open": "^8.0.2",
         "openid-client": "^4.4.2",
         "ora": "^5.1.0",
@@ -29453,7 +29453,7 @@
     },
     "packages/core": {
       "name": "@outsmartly/core",
-      "version": "0.0.5",
+      "version": "0.0.7",
       "license": "MIT",
       "devDependencies": {
         "msw": "^0.33.1",
@@ -33751,7 +33751,7 @@
         "globby": "^10",
         "inquirer": "^7.3.3",
         "multiline-template": "^1.1.0",
-        "node-fetch": "3.0.0-beta.9",
+        "node-fetch": "^3.0.0-beta.9",
         "nyc": "^14",
         "open": "^8.0.2",
         "openid-client": "^4.4.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outsmartly/cli",
   "description": "Command Line Interface for Outsmartly.",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "license": "MIT",
   "bin": {
     "outsmartly": "bin/outsmartly"


### PR DESCRIPTION
Looks like the oclif.manifest.json file was out of date for 0.0.80 and so 0.0.81 had to be published to fix it. Quick PR to update the version so the upstream branch is up to date!