### PR TITLE
Edge facebookPlugin

### DIFF
--- a/packages/plugin-facebook/README.md
+++ b/packages/plugin-facebook/README.md
@@ -1,6 +1,6 @@
 # @outsmartly/plugin-facebook
 
-> Trigger facebook events as per messagebus events at the edge
+> Configure facebook serverside events using messagebus listeners at the edge
 
 ## Install
 
@@ -53,6 +53,13 @@ facebookPlugin({
 ## Todo to support all facebook standard events
 
 [List of facebook standard events](https://developers.facebook.com/docs/facebook-pixel/reference#standard-events)
+
+## Test setup
+
+```bash
+# cd packages/plugin-facebook
+npm test
+```
 
 ## References facebook developer docs
 

--- a/packages/plugin-facebook/README.md
+++ b/packages/plugin-facebook/README.md
@@ -1,0 +1,62 @@
+# @outsmartly/plugin-facebook
+
+> Trigger facebook events as per messagebus events at the edge
+
+## Install
+
+```bash
+npm install --save @outsmartly/plugin-facebook
+# or
+yarn add @outsmartly/plugin-facebook
+```
+
+## Setup
+
+Inside your `outsmartly.config.js` you can configure the `facebookPlugin()` and pass the result into the `plugins` array as below:
+
+```js
+import { facebookPlugin } from '@outsmartly/plugin-facebook';
+
+export default {
+  host: 'project.outsmartly.app',
+  environments: [
+    {
+      name: 'production',
+      origin: 'https://origin.com',
+    },
+  ],
+  plugins: [
+    facebookPlugin({
+      ACCESS_TOKEN: '<facebook-access-token>',
+      PIXEL_ID: '<facebook-pixel-id>',
+    }),
+  ],
+};
+```
+
+In order to test sample facebook events few extra parameters can be passed to `facebookPlugin()` as below:
+
+```js
+facebookPlugin({
+  ACCESS_TOKEN: '<facebook-access-token>',
+  PIXEL_ID: '<facebook-pixel-id>',
+  FB_TEST_EVENT: true, // default false
+  TEST_EVENT_CODE: '<facebook-test-event-code>',// TEST29501
+}),
+```
+
+## Implemented facebook events
+
+- AddToCart
+- PageView
+
+## Todo to support all facebook standard events
+
+[List of facebook standard events](https://developers.facebook.com/docs/facebook-pixel/reference#standard-events)
+
+## References facebook developer docs
+
+- Facebook [standard events](https://developers.facebook.com/docs/facebook-pixel/reference#standard-events)
+- Facebook [custom events](https://developers.facebook.com/docs/facebook-pixel/implementation/conversion-tracking/#custom-events)
+- Get started [using the conversions API](https://business.facebook.com/events_manager2/implementation_instructions/<some-pixel-id>?business_id=272015681234878)
+- [Payload helper](https://developers.facebook.com/docs/marketing-api/conversions-api/payload-helper)

--- a/packages/plugin-facebook/jest.config.js
+++ b/packages/plugin-facebook/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  roots: ['<rootDir>/src/'],
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/tests/setupJest.ts'],
+};

--- a/packages/plugin-facebook/package.json
+++ b/packages/plugin-facebook/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.7",
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^27.0.0",
     "@types/node": "^16.4.5",
     "event-target-polyfill": "0.0.3",
     "fast-text-encoding": "^1.0.3",

--- a/packages/plugin-facebook/package.json
+++ b/packages/plugin-facebook/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@outsmartly/plugin-facebook",
+  "version": "0.0.1",
+  "description": "facebook serverside events deployed at the edge",
+  "author": "Outsmartly <hello@outsmartly.com>",
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "peerDependencies": {
+    "typescript": "^4.3.5"
+  },
+  "devDependencies": {
+    "@peculiar/webcrypto": "^1.1.7",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^16.4.5",
+    "event-target-polyfill": "0.0.3",
+    "fast-text-encoding": "^1.0.3",
+    "jest": "^27.0.6",
+    "jest-fetch-mock": "^3.0.3",
+    "ts-jest": "^27.0.4"
+  },
+  "dependencies": {
+    "@outsmartly/core": "0.0.7",
+    "@outsmartly/message-bus": "0.0.2"
+  }
+}

--- a/packages/plugin-facebook/src/__tests__/addToCart.test.ts
+++ b/packages/plugin-facebook/src/__tests__/addToCart.test.ts
@@ -1,0 +1,214 @@
+import {
+  OutsmartlyEvent,
+  OutsmartlyEdgeVisitor,
+  OutsmartlyReadonlyCookies,
+  EdgeMessageBus,
+  MessageBus,
+  MessageBusListener,
+  OutsmartlyMessageEvent,
+  MessageBusMessage,
+} from '@outsmartly/core';
+import fetchMock from 'jest-fetch-mock';
+
+import { facebookPlugin } from '..';
+import { FBC_COOKIE_KEY, FBP_COOKIE_KEY } from '../fbcookies';
+
+describe('facebookPlugin() AddToCart', () => {
+  class TestMessageEvent<T extends string, D>
+    extends OutsmartlyEvent
+    implements OutsmartlyMessageEvent<T, D> {
+    type!: 'outsmartlyedgemessage';
+    constructor(
+      public messageBus: MessageBus,
+      public visitor: OutsmartlyEdgeVisitor,
+      public message: MessageBusMessage<T, D>,
+      public cookies: OutsmartlyReadonlyCookies,
+    ) {
+      super('outsmartlyedgemessage');
+    }
+  }
+
+  const notifyListener = jest.fn();
+  const waitUntil = jest.fn();
+  class TestMessageBus extends MessageBus {
+    _notifyListener = notifyListener;
+    _waitUntil = waitUntil;
+    _writeToExternal = jest.fn();
+  }
+
+  let messageBus!: TestMessageBus;
+
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+  beforeEach(() => {
+    messageBus = new TestMessageBus();
+    fetchMock.resetMocks();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  afterAll(() => {
+    fetchMock.mockRestore();
+  });
+
+  const queueMacrotask = () => new Promise((resolve) => setTimeout(resolve, 0));
+  async function repeatUntilPassing(callback: () => void) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        callback();
+        break;
+      } catch (e) {
+        await queueMacrotask();
+      }
+    }
+  }
+
+  const notifyListenerHandler = (
+    listener: MessageBusListener<OutsmartlyMessageEvent<string, unknown>>,
+    message: MessageBusMessage<string, unknown>,
+  ) => {
+    const visitor = {
+      id: '<some-id>',
+      ipAddress: '<some-ip-address>',
+      city: '<some-city>',
+      userAgent: '',
+    } as any;
+    const cookies = new OutsmartlyReadonlyCookies([
+      [FBC_COOKIE_KEY, '<FBC_COOKIE_KEY>'],
+      [FBP_COOKIE_KEY, '<FBP_COOKIE_KEY>'],
+    ]);
+    const event = new TestMessageEvent(messageBus, visitor, message, cookies);
+    listener(event);
+  };
+
+  const data = [
+    {
+      event_name: 'AddToCart',
+      event_time: Math.floor(1629478895070 / 1000),
+      action_source: 'website',
+      event_source_url: '<some-url>',
+      user_data: {
+        client_user_agent: '',
+        client_ip_address: '<some-ip-address>',
+        fbp: '<FBP_COOKIE_KEY>',
+        fbc: '<FBC_COOKIE_KEY>',
+        external_id: {},
+        ct: {},
+      },
+      custom_data: {},
+    },
+  ];
+
+  const FB_ADD_TO_CART_REQ_BODY = {
+    data,
+    access_token: '<some-access-token>',
+  };
+
+  const TEST_FB_ADD_TO_CART_REQ_BODY = {
+    data,
+    access_token: '<some-access-token>',
+    test_event_code: 'TEST29501',
+  };
+
+  it('sends Facebook AddToCart messages for Commerce.Cart.ADD_TO_CART', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+
+    notifyListener.mockImplementationOnce(notifyListenerHandler);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+    });
+    plugin.setup?.({
+      config: {
+        host: '',
+        plugins: [plugin],
+        environments: [],
+        middleware: [],
+        routes: [],
+      },
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    fetchMock.mockOnce('', {
+      status: 200,
+    });
+
+    messageBus.emit('Commerce.Cart.ADD_TO_CART', {
+      event_source_url: '<some-url>',
+      customer_data: {},
+      custom_data: {},
+    });
+
+    await repeatUntilPassing(() => {
+      expect(fetchMock).toBeCalledTimes(1);
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://graph.facebook.com/v11.0/<some-pixel-id>/events',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json;',
+        },
+        body: JSON.stringify(FB_ADD_TO_CART_REQ_BODY, null, 2),
+      },
+    );
+    dateNowSpy.mockRestore();
+  });
+
+  it('sends Facebook test AddToCart messages for Commerce.Cart.ADD_TO_CART', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+
+    notifyListener.mockImplementationOnce(notifyListenerHandler);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+      FB_TEST_EVENT: true,
+      TEST_EVENT_CODE: 'TEST29501',
+    });
+    plugin.setup?.({
+      config: {
+        host: '',
+        plugins: [plugin],
+        environments: [],
+        middleware: [],
+        routes: [],
+      },
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    fetchMock.mockOnce('', {
+      status: 200,
+    });
+
+    messageBus.emit('Commerce.Cart.ADD_TO_CART', {
+      event_source_url: '<some-url>',
+      customer_data: {},
+      custom_data: {},
+    });
+
+    await repeatUntilPassing(() => {
+      expect(fetchMock).toBeCalledTimes(1);
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://graph.facebook.com/v11.0/<some-pixel-id>/events',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json;',
+        },
+        body: JSON.stringify(TEST_FB_ADD_TO_CART_REQ_BODY, null, 2),
+      },
+    );
+    dateNowSpy.mockRestore();
+  });
+});

--- a/packages/plugin-facebook/src/__tests__/index.test.ts
+++ b/packages/plugin-facebook/src/__tests__/index.test.ts
@@ -1,0 +1,151 @@
+import {
+  OutsmartlyEvent,
+  OutsmartlyCookies,
+  EdgeMessageBus,
+  MessageBus,
+  OutsmartlyMiddlewareEvent,
+  OutsmartlyConfig,
+} from '@outsmartly/core';
+import fetchMock from 'jest-fetch-mock';
+
+import { facebookPlugin } from '..';
+import { FBC_COOKIE_KEY, FBP_COOKIE_KEY } from '../fbcookies';
+
+describe('facebookPlugin() handle _fbp & _fbc cookies', () => {
+  const notifyListener = jest.fn();
+  const waitUntil = jest.fn();
+  class TestMessageBus extends MessageBus {
+    _notifyListener = notifyListener;
+    _waitUntil = waitUntil;
+    _writeToExternal = jest.fn();
+  }
+
+  let messageBus!: TestMessageBus;
+
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+  beforeEach(() => {
+    messageBus = new TestMessageBus();
+    fetchMock.resetMocks();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  afterAll(() => {
+    fetchMock.mockRestore();
+  });
+
+  class MockOutsmartlyMiddlewareEvent
+    extends OutsmartlyEvent
+    implements OutsmartlyMiddlewareEvent {
+    type!: 'outsmartlymiddleware';
+
+    constructor(public cookies: OutsmartlyCookies, public url: URL) {
+      super('outsmartlymiddleware');
+    }
+
+    // These aren't used, so no sense in mocking them right now.
+    messageBus = null as any;
+    visitor = null as any;
+    request = null as any;
+    state = null as any;
+    waitUntil = null as any;
+    log = null as any;
+    warn = null as any;
+    error = null as any;
+  }
+
+  it('sets _fbp and _fbc cookies if both are not defined and there is a ?fbclid query param', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+    const mathRandomSpy = jest
+      .spyOn(Math, 'random')
+      .mockImplementation(() => 0.5);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+      FB_TEST_EVENT: true,
+      TEST_EVENT_CODE: 'TEST29501',
+    });
+    const config: Required<OutsmartlyConfig> = {
+      host: '',
+      plugins: [plugin],
+      environments: [],
+      middleware: [],
+      routes: [],
+    };
+    plugin.setup!({
+      config,
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    const cookies = new OutsmartlyCookies([]);
+    const url = new URL('https://example.com/?fbclid=<some=fbclid>');
+    const event = new MockOutsmartlyMiddlewareEvent(cookies, url);
+    const next = jest.fn();
+
+    expect(cookies.has(FBP_COOKIE_KEY)).toBe(false);
+    expect(cookies.has(FBC_COOKIE_KEY)).toBe(false);
+
+    config.middleware![0](event, next);
+
+    expect(cookies.get(FBP_COOKIE_KEY)).toBe('fb.1.1629478895070.5500000000');
+    expect(cookies.get(FBC_COOKIE_KEY)).toBe(
+      'fb.1.1629478895070.<some=fbclid>',
+    );
+
+    expect(next).toBeCalledTimes(1);
+    expect(next).toBeCalledWith(/* nothing */);
+
+    dateNowSpy.mockRestore();
+    mathRandomSpy.mockRestore();
+  });
+
+  it('does not set any of the cookies if _fbp is already defined, and there is no ?fbclid', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+    const mathRandomSpy = jest
+      .spyOn(Math, 'random')
+      .mockImplementation(() => 0.5);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+      FB_TEST_EVENT: true,
+      TEST_EVENT_CODE: 'TEST29501',
+    });
+    const config: Required<OutsmartlyConfig> = {
+      host: '',
+      plugins: [plugin],
+      environments: [],
+      middleware: [],
+      routes: [],
+    };
+    plugin.setup!({
+      config,
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    const cookies = new OutsmartlyCookies([
+      [FBP_COOKIE_KEY, '<some-fbp-value>'],
+    ]);
+    const url = new URL('https://example.com/');
+    const event = new MockOutsmartlyMiddlewareEvent(cookies, url);
+    const next = jest.fn();
+
+    config.middleware![0](event, next);
+
+    expect(cookies.get(FBP_COOKIE_KEY)).toBe('<some-fbp-value>');
+    expect(cookies.has(FBC_COOKIE_KEY)).toBe(false);
+
+    expect(next).toBeCalledTimes(1);
+    expect(next).toBeCalledWith(/* nothing */);
+
+    dateNowSpy.mockRestore();
+    mathRandomSpy.mockRestore();
+  });
+});

--- a/packages/plugin-facebook/src/__tests__/pageView.test.ts
+++ b/packages/plugin-facebook/src/__tests__/pageView.test.ts
@@ -1,0 +1,214 @@
+import {
+  OutsmartlyEvent,
+  OutsmartlyEdgeVisitor,
+  OutsmartlyReadonlyCookies,
+  EdgeMessageBus,
+  MessageBus,
+  MessageBusListener,
+  OutsmartlyMessageEvent,
+  MessageBusMessage,
+} from '@outsmartly/core';
+import fetchMock from 'jest-fetch-mock';
+
+import { facebookPlugin } from '..';
+import { FBC_COOKIE_KEY, FBP_COOKIE_KEY } from '../fbcookies';
+
+describe('facebookPlugin() PageView', () => {
+  class TestMessageEvent<T extends string, D>
+    extends OutsmartlyEvent
+    implements OutsmartlyMessageEvent<T, D> {
+    type!: 'outsmartlyedgemessage';
+    constructor(
+      public messageBus: MessageBus,
+      public visitor: OutsmartlyEdgeVisitor,
+      public message: MessageBusMessage<T, D>,
+      public cookies: OutsmartlyReadonlyCookies,
+    ) {
+      super('outsmartlyedgemessage');
+    }
+  }
+
+  const notifyListener = jest.fn();
+  const waitUntil = jest.fn();
+  class TestMessageBus extends MessageBus {
+    _notifyListener = notifyListener;
+    _waitUntil = waitUntil;
+    _writeToExternal = jest.fn();
+  }
+
+  let messageBus!: TestMessageBus;
+
+  beforeAll(() => {
+    fetchMock.enableMocks();
+  });
+  beforeEach(() => {
+    messageBus = new TestMessageBus();
+    fetchMock.resetMocks();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  afterAll(() => {
+    fetchMock.mockRestore();
+  });
+
+  const queueMacrotask = () => new Promise((resolve) => setTimeout(resolve, 0));
+  async function repeatUntilPassing(callback: () => void) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        callback();
+        break;
+      } catch (e) {
+        await queueMacrotask();
+      }
+    }
+  }
+
+  const notifyListenerHandler = (
+    listener: MessageBusListener<OutsmartlyMessageEvent<string, unknown>>,
+    message: MessageBusMessage<string, unknown>,
+  ) => {
+    const visitor = {
+      id: '<some-id>',
+      ipAddress: '<some-ip-address>',
+      city: '<some-city>',
+      userAgent: '',
+    } as any;
+    const cookies = new OutsmartlyReadonlyCookies([
+      [FBC_COOKIE_KEY, '<FBC_COOKIE_KEY>'],
+      [FBP_COOKIE_KEY, '<FBP_COOKIE_KEY>'],
+    ]);
+    const event = new TestMessageEvent(messageBus, visitor, message, cookies);
+    listener(event);
+  };
+
+  const data = [
+    {
+      event_name: 'PageView',
+      event_time: Math.floor(1629478895070 / 1000),
+      action_source: 'website',
+      event_source_url: '<some-url>',
+      user_data: {
+        client_user_agent: '',
+        client_ip_address: '<some-ip-address>',
+        fbp: '<FBP_COOKIE_KEY>',
+        fbc: '<FBC_COOKIE_KEY>',
+        external_id: {},
+        ct: {},
+      },
+      custom_data: {},
+    },
+  ];
+
+  const FB_PAGE_VIEW_REQ_BODY = {
+    data,
+    access_token: '<some-access-token>',
+  };
+
+  const TEST_FB_PAGE_VIEW_REQ_BODY = {
+    data,
+    access_token: '<some-access-token>',
+    test_event_code: 'TEST29501',
+  };
+
+  it('sends Facebook PageView messages for Commerce.PAGE_VIEW', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+
+    notifyListener.mockImplementationOnce(notifyListenerHandler);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+    });
+    plugin.setup?.({
+      config: {
+        host: '',
+        plugins: [plugin],
+        environments: [],
+        middleware: [],
+        routes: [],
+      },
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    fetchMock.mockOnce('', {
+      status: 200,
+    });
+
+    messageBus.emit('Commerce.PAGE_VIEW', {
+      event_source_url: '<some-url>',
+      customer_data: {},
+      custom_data: {},
+    });
+
+    await repeatUntilPassing(() => {
+      expect(fetchMock).toBeCalledTimes(1);
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://graph.facebook.com/v11.0/<some-pixel-id>/events',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json;',
+        },
+        body: JSON.stringify(FB_PAGE_VIEW_REQ_BODY, null, 2),
+      },
+    );
+    dateNowSpy.mockRestore();
+  });
+
+  it('sends Facebook test PageView messages for Commerce.PAGE_VIEW', async () => {
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => 1629478895070);
+
+    notifyListener.mockImplementationOnce(notifyListenerHandler);
+
+    const plugin = facebookPlugin({
+      ACCESS_TOKEN: '<some-access-token>',
+      PIXEL_ID: '<some-pixel-id>',
+      FB_TEST_EVENT: true,
+      TEST_EVENT_CODE: 'TEST29501',
+    });
+    plugin.setup?.({
+      config: {
+        host: '',
+        plugins: [plugin],
+        environments: [],
+        middleware: [],
+        routes: [],
+      },
+      messageBus: (messageBus as any) as EdgeMessageBus,
+    });
+
+    fetchMock.mockOnce('', {
+      status: 200,
+    });
+
+    messageBus.emit('Commerce.PAGE_VIEW', {
+      event_source_url: '<some-url>',
+      customer_data: {},
+      custom_data: {},
+    });
+
+    await repeatUntilPassing(() => {
+      expect(fetchMock).toBeCalledTimes(1);
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://graph.facebook.com/v11.0/<some-pixel-id>/events',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json;',
+        },
+        body: JSON.stringify(TEST_FB_PAGE_VIEW_REQ_BODY, null, 2),
+      },
+    );
+    dateNowSpy.mockRestore();
+  });
+});

--- a/packages/plugin-facebook/src/events/addToCart.ts
+++ b/packages/plugin-facebook/src/events/addToCart.ts
@@ -1,0 +1,25 @@
+const FB_ADD_TO_CART: string = 'AddToCart';
+import { sendFbEvent } from '../fbevents';
+import { OutsmartlyEdgeMessageEvent } from '@outsmartly/core';
+
+interface AddToCartData {
+  event_source_url: string;
+  customer_data: any;
+  custom_data: any;
+}
+type AddToCartMessageEvent = OutsmartlyEdgeMessageEvent<
+  typeof FB_ADD_TO_CART,
+  AddToCartData
+>;
+export async function addToCart(event: AddToCartMessageEvent) {
+  const { message } = event;
+  const { event_source_url, customer_data, custom_data } = message.data;
+
+  await sendFbEvent({
+    event,
+    event_name: FB_ADD_TO_CART,
+    event_source_url,
+    customer_data,
+    custom_data,
+  });
+}

--- a/packages/plugin-facebook/src/events/index.ts
+++ b/packages/plugin-facebook/src/events/index.ts
@@ -1,0 +1,11 @@
+import { EdgeMessageBus } from '@outsmartly/core';
+import { addToCart } from './addToCart';
+import { pageView } from './pageView';
+
+const OUTSMARTLY_ADD_TO_CART: string = 'Commerce.Cart.ADD_TO_CART';
+const OUTSMARTLY_PAGE_VIEW: string = 'Commerce.PAGE_VIEW';
+
+export function configure(messageBus: EdgeMessageBus) {
+  messageBus.on(OUTSMARTLY_ADD_TO_CART, addToCart);
+  messageBus.on(OUTSMARTLY_PAGE_VIEW, pageView);
+}

--- a/packages/plugin-facebook/src/events/pageView.ts
+++ b/packages/plugin-facebook/src/events/pageView.ts
@@ -1,0 +1,25 @@
+const FB_PAGE_VIEW: string = 'PageView';
+import { sendFbEvent } from '../fbevents';
+import { OutsmartlyEdgeMessageEvent } from '@outsmartly/core';
+
+interface PageViewData {
+  event_source_url: string;
+  customer_data: any;
+  custom_data: any;
+}
+type PageViewMessageEvent = OutsmartlyEdgeMessageEvent<
+  typeof FB_PAGE_VIEW,
+  PageViewData
+>;
+export async function pageView(event: PageViewMessageEvent) {
+  const { message } = event;
+  const { event_source_url, customer_data, custom_data } = message.data;
+
+  sendFbEvent({
+    event,
+    event_name: FB_PAGE_VIEW,
+    event_source_url,
+    customer_data,
+    custom_data,
+  });
+}

--- a/packages/plugin-facebook/src/fbCookies.ts
+++ b/packages/plugin-facebook/src/fbCookies.ts
@@ -1,0 +1,46 @@
+import { OutsmartlyCookies, OutsmartlyMiddlewareEvent } from '@outsmartly/core';
+
+export const FBP_COOKIE_KEY: string = '_fbp';
+export const FBC_COOKIE_KEY: string = '_fbc';
+
+export function setupFbpFbc(event: OutsmartlyMiddlewareEvent) {
+  verifyAndSetFbp(event.cookies);
+  verifyAndSetFbc(event);
+}
+
+function verifyAndSetFbp(cookies: OutsmartlyCookies): void {
+  if (!cookies.has(FBP_COOKIE_KEY)) {
+    const fbpValue = createFbp();
+    cookies.set(FBP_COOKIE_KEY, fbpValue, {
+      httpOnly: true,
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7 * 365,
+    });
+  }
+}
+
+function randomInteger(): number {
+  return Math.floor(1000000000 + Math.random() * 9000000000);
+}
+
+function createFbp(): string {
+  return `fb.1.${Date.now()}.${randomInteger()}`;
+}
+
+function verifyAndSetFbc(event: OutsmartlyMiddlewareEvent): void {
+  const { cookies } = event;
+  const fbclid = event.url.searchParams.get('fbclid');
+
+  if (fbclid) {
+    const fbc = createFbc(fbclid);
+    cookies.set(FBC_COOKIE_KEY, fbc, {
+      httpOnly: true,
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7 * 365,
+    });
+  }
+}
+
+function createFbc(fbclid: unknown): string {
+  return `fb.1.${Date.now()}.${fbclid}`;
+}

--- a/packages/plugin-facebook/src/fbEvents.ts
+++ b/packages/plugin-facebook/src/fbEvents.ts
@@ -1,0 +1,128 @@
+import { EdgeMessageBus, OutsmartlyEdgeMessageEvent } from '@outsmartly/core';
+import { FbCustomerInformation, CustomerData, getUserData } from './fbuser';
+import { configure } from './events';
+
+export interface ConfigureFbEvents {
+  messageBus: EdgeMessageBus;
+  options: Options;
+}
+
+export interface Options {
+  ACCESS_TOKEN: string;
+  PIXEL_ID: string;
+  FB_TEST_EVENT?: boolean;
+  TEST_EVENT_CODE?: string;
+}
+
+const configs: Options = {
+  ACCESS_TOKEN: '',
+  PIXEL_ID: '',
+  FB_TEST_EVENT: false,
+  TEST_EVENT_CODE: '',
+};
+
+export function setupFbEvents({
+  messageBus,
+  options,
+}: ConfigureFbEvents): void {
+  configs.ACCESS_TOKEN = options.ACCESS_TOKEN || '';
+  configs.PIXEL_ID = options.PIXEL_ID || '';
+  configs.FB_TEST_EVENT = options.FB_TEST_EVENT || false;
+  configs.TEST_EVENT_CODE = options.TEST_EVENT_CODE || '';
+
+  configure(messageBus);
+}
+
+interface CustomData {
+  currency?: string;
+}
+
+export interface TrackFbEvent {
+  event: OutsmartlyEdgeMessageEvent<string, unknown>;
+  event_name: string;
+  event_source_url: string;
+  customer_data?: CustomerData;
+  custom_data?: CustomData;
+}
+
+/**
+ * Track facebook event
+ * @param event
+ * @param event_name
+ */
+export async function sendFbEvent({
+  event,
+  event_name,
+  event_source_url,
+  customer_data = {},
+  custom_data = {},
+}: TrackFbEvent): Promise<void> {
+  const event_time: number = Math.floor(Date.now() / 1000);
+  const action_source: string = 'website';
+  const user_data: FbCustomerInformation = await getUserData(
+    event,
+    customer_data,
+  );
+
+  const payload: FacebookEventData = {
+    data: [
+      {
+        event_name,
+        event_time,
+        action_source,
+        event_source_url,
+        user_data,
+        custom_data,
+      },
+    ],
+    access_token: configs.ACCESS_TOKEN,
+  };
+
+  /**
+   * Check if FB test events are enabled
+   * Then add fb test event code to see fb test events
+   */
+  if (configs.FB_TEST_EVENT) {
+    payload.test_event_code = configs.TEST_EVENT_CODE;
+  }
+
+  await postDataToFb(payload);
+}
+
+interface FacebookEventData {
+  data: [
+    {
+      event_name: string;
+      event_time: number;
+      action_source: string;
+      event_source_url: string;
+      user_data: FbCustomerInformation;
+      custom_data?: unknown;
+    },
+  ];
+  access_token: string;
+  test_event_code?: string;
+}
+
+/**
+ * Post data to Facebook API
+ */
+async function postDataToFb(data: FacebookEventData) {
+  const API_VERSION = 'v11.0';
+  const PIXEL_ID = configs.PIXEL_ID || '';
+  const API_URL: string = `https://graph.facebook.com/${API_VERSION}/${PIXEL_ID}/events`;
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json;',
+    },
+    body: JSON.stringify(data, null, 2),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `@outsmartly/plugin-facebook: postDataToFb() received ${response.status} response:\n${text}`,
+    );
+  }
+}

--- a/packages/plugin-facebook/src/fbUser.ts
+++ b/packages/plugin-facebook/src/fbUser.ts
@@ -1,0 +1,55 @@
+import { OutsmartlyEdgeMessageEvent } from '@outsmartly/core';
+import { hash } from './utils';
+import { FBP_COOKIE_KEY, FBC_COOKIE_KEY } from './fbcookies';
+
+export interface FbCustomerInformation {
+  client_user_agent: string;
+  client_ip_address: string;
+  external_id: ArrayBuffer;
+  fbp: string | undefined;
+  fbc?: string | undefined;
+  em?: ArrayBuffer;
+  ph?: ArrayBuffer;
+  ct?: ArrayBuffer;
+}
+
+export interface CustomerData {
+  email?: string;
+  phone?: string;
+}
+
+/**
+ * Extract user data to be passed to facebook
+ */
+export async function getUserData(
+  event: OutsmartlyEdgeMessageEvent<string, unknown>,
+  customer_data: CustomerData,
+): Promise<FbCustomerInformation> {
+  const { visitor, cookies } = event;
+  const { id, ipAddress, city /* userAgent */ } = visitor;
+  const { email, phone } = customer_data;
+
+  const eid: ArrayBuffer = await hash(id);
+
+  const data: FbCustomerInformation = {
+    client_user_agent: /* userAgent */ '',
+    client_ip_address: ipAddress,
+    fbp: cookies.get(FBP_COOKIE_KEY) || '',
+    fbc: cookies.get(FBC_COOKIE_KEY) || '',
+    external_id: eid,
+  };
+
+  if (city) {
+    data.ct = await hash(city);
+  }
+
+  if (email) {
+    data.em = await hash(email);
+  }
+
+  if (phone) {
+    data.ph = await hash(phone);
+  }
+
+  return data;
+}

--- a/packages/plugin-facebook/src/index.ts
+++ b/packages/plugin-facebook/src/index.ts
@@ -1,0 +1,26 @@
+import { setupFbpFbc } from './fbcookies';
+import { setupFbEvents, Options } from './fbevents';
+import { OutsmartlyMiddlewareEvent, Plugin } from '@outsmartly/core';
+
+export function facebookPlugin(options: Options): Plugin {
+  return {
+    name: '@outsmartly/plugin-facebook',
+    setup({ config, messageBus }) {
+      /**
+       * Handle fbp & fbc cookies for each user
+       */
+      config.middleware?.unshift(
+        async (event: OutsmartlyMiddlewareEvent, next) => {
+          setupFbpFbc(event);
+          const response = await next();
+          return response;
+        },
+      );
+
+      /**
+       * Configure all facebook events as per EdgeMessagebus events
+       */
+      setupFbEvents({ messageBus, options });
+    },
+  };
+}

--- a/packages/plugin-facebook/src/utils.ts
+++ b/packages/plugin-facebook/src/utils.ts
@@ -1,0 +1,12 @@
+export async function hash(str: string) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str);
+  const hashencoded = await crypto.subtle.digest('SHA-256', data);
+  return hashencoded;
+}
+
+export function decodeToString(encodedstr: ArrayBuffer) {
+  const decoder = new TextDecoder('utf-8');
+  const decodedstr = decoder.decode(encodedstr);
+  return decodedstr;
+}

--- a/packages/plugin-facebook/tests/setupJest.ts
+++ b/packages/plugin-facebook/tests/setupJest.ts
@@ -1,0 +1,5 @@
+import 'event-target-polyfill';
+import 'fast-text-encoding';
+import { Crypto } from '@peculiar/webcrypto';
+
+globalThis.crypto = new Crypto();

--- a/packages/plugin-facebook/tsconfig.json
+++ b/packages/plugin-facebook/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES5", "WebWorker", "ES2015"],
+    "allowJs": true,
+    "strict": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "allowSyntheticDefaultImports": true,
+    "removeComments": true,
+    "outDir": "dist/",
+    "typeRoots": ["../../node_modules/@types/", "node_modules/@types/"]
+  },
+  "include": ["src/**/*.ts", "types/**/*.ts"],
+  "exclude": ["node_modules/", "dist/"]
+}


### PR DESCRIPTION
# Edge facebookPlugin

> Configure facebook serverside events using messagebus listeners at the edge

Integrated `AddToCart` & 'PageView' among other [facebook standard events](https://developers.facebook.com/docs/facebook-pixel/reference#standard-events).

