### PR TITLE
Revert remotes changes

### DIFF
--- a/packages/core/src/public/types.ts
+++ b/packages/core/src/public/types.ts
@@ -152,7 +152,12 @@ export declare class OutsmartlyOverrideEvent extends OutsmartlyEdgeRequestEvent 
   getComponentArguments<R extends unknown[]>(): Promise<R>;
 }
 
-export interface Remote {
+export interface Environment {
+  /**
+   * Currently, only `name: 'production'` is supported.
+   */
+  name: 'production';
+
   /**
    * Your origin is where Outsmartly's CDN proxies requests to.
    * Here are some examples:
@@ -165,8 +170,6 @@ export interface Remote {
    * such as `https://` but it does NOT include any path.
    */
   origin: string;
-  default?: boolean;
-  artifacts?: boolean;
 }
 
 export interface Middleware {
@@ -268,10 +271,10 @@ export interface OutsmartlyConfig {
   host: string;
 
   /**
-   * The possible deployment remotes.
-   * @see Remote
+   * The possible deployment environments.
+   * @see Environment
    */
-  remotes?: Remote[];
+  environments: Environment[];
 
   /**
    * Optional plugins made for Outsmartly's edge


### PR DESCRIPTION
Reverting the changes since we're not going to work on supporting multiple artifacts right now. I didn't do an actual `git revert` because there were some `package-lock.json` changes that should stick around.